### PR TITLE
Support of multiple options of the same name within one section.

### DIFF
--- a/concierge/core/processor.py
+++ b/concierge/core/processor.py
@@ -19,8 +19,9 @@ def generate(tree):
     for host in flat(tree):
         yield "Host {}".format(host.fullname)
 
-        for option, value in sorted(host.options.items()):
-            yield "    {} {}".format(option, value)
+        for option, values in sorted(host.options.items()):
+            for value in sorted(values):
+                yield "    {} {}".format(option, value)
 
         yield ""
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -77,60 +77,60 @@ Host *
     star_host = tree.hosts[0]
     assert star_host.trackable
     assert star_host.fullname == "*"
-    assert star_host.options == {"Compression": "yes",
-                                 "CompressionLevel": "6"}
+    assert star_host.options == {"Compression": ["yes"],
+                                 "CompressionLevel": ["6"]}
 
     m_host = tree.hosts[1]
     assert m_host.trackable
     assert m_host.fullname == "m"
-    assert m_host.options == {"Port": "22"}
+    assert m_host.options == {"Port": ["22"]}
     assert len(m_host.hosts) == 4
 
     me_host = m_host.hosts[0]
     assert me_host.trackable
     assert me_host.fullname == "me"
-    assert me_host.options == {"Port": "22", "HostName": "env10",
-                               "User": "root"}
+    assert me_host.options == {"Port": ["22"], "HostName": ["env10"],
+                               "User": ["root"]}
     assert len(me_host.hosts) == 1
 
     mewww_host = me_host.hosts[0]
     assert mewww_host.trackable
     assert mewww_host.fullname == "meWWW"
-    assert mewww_host.options == {"Port": "22", "TCPKeepAlive": "5",
-                                  "HostName": "env10", "User": "root"}
+    assert mewww_host.options == {"Port": ["22"], "TCPKeepAlive": ["5"],
+                                  "HostName": ["env10"], "User": ["root"]}
     assert mewww_host.hosts == []
 
     mq_host = m_host.hosts[1]
     assert mq_host.trackable
     assert mq_host.fullname == "mq"
-    assert mq_host.options == {"Protocol": "2", "Port": "22"}
+    assert mq_host.options == {"Protocol": ["2"], "Port": ["22"]}
     assert mq_host.hosts == []
 
     mv_host = m_host.hosts[2]
     assert mv_host.trackable
     assert mv_host.fullname == "mv"
-    assert mv_host.options == {"Port": "22", "HostName": "env10",
-                               "User": "root"}
+    assert mv_host.options == {"Port": ["22"], "HostName": ["env10"],
+                               "User": ["root"]}
     assert len(mv_host.hosts) == 1
 
     mvwww_host = mv_host.hosts[0]
     assert mvwww_host.trackable
     assert mvwww_host.fullname == "mvWWW"
-    assert mvwww_host.options == {"Port": "22", "TCPKeepAlive": "5",
-                                  "HostName": "env10", "User": "root"}
+    assert mvwww_host.options == {"Port": ["22"], "TCPKeepAlive": ["5"],
+                                  "HostName": ["env10"], "User": ["root"]}
     assert mvwww_host.hosts == []
 
     mx_host = m_host.hosts[3]
     assert not mx_host.trackable
     assert mx_host.fullname == "mx"
-    assert mx_host.options == {"SendEnv": "12", "Port": "22"}
+    assert mx_host.options == {"SendEnv": ["12"], "Port": ["22"]}
     assert len(mx_host.hosts) == 1
 
     mxqex_host = mx_host.hosts[0]
     assert mxqex_host.trackable
     assert mxqex_host.fullname == "mxqex"
-    assert mxqex_host.options == {"SendEnv": "12", "Port": "35",
-                                  "ProxyCommand": "ssh -W %h:%p env312"}
+    assert mxqex_host.options == {"SendEnv": ["12"], "Port": ["35"],
+                                  "ProxyCommand": ["ssh -W %h:%p env312"]}
     assert mxqex_host.hosts == []
 
 
@@ -159,6 +159,27 @@ Host *
 
     assert no_star_host.struct == star_host.struct
     assert no_star_host.struct == star_host_only.struct
+
+
+def test_parse_multiple_options():
+    config = """\
+
+Host q
+    User root
+
+Host name
+    User rooter
+
+    LocalForward 80 brumm:80
+    LocalForward 443 brumm:443
+    LocalForward 22 brumm:23
+""".strip()
+
+    parsed = parser.parse(lexer.lex(config.split("\n")))
+    assert sorted(parsed.hosts[1].options["LocalForward"]) == [
+        "22 brumm:23",
+        "443 brumm:443",
+        "80 brumm:80"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_parser_host.py
+++ b/tests/test_parser_host.py
@@ -60,10 +60,25 @@ def test_options():
 
     host1["a"] = 1
 
-    assert host1.values == host1.options
-    assert host1.options == {"a": 1}
+    assert len(host1.values) == len(host1.options)
+    for key, value in host1.values.items():
+        assert sorted(value) == sorted(host1.options[key])
+    assert host1.options == {"a": [1]}
 
-    assert host1["a"] == 1
+    assert host1["a"] == [1]
+
+
+def test_options_several():
+    host = parser.Host("a", None)
+
+    host["a"] = 1
+    assert host.options == {"a": [1]}
+
+    host["a"] = 3
+    assert host.options == {"a": [1, 3]}
+
+    host["a"] = 2
+    assert host.options == {"a": [1, 2, 3]}
 
 
 def test_options_overlap():
@@ -72,15 +87,15 @@ def test_options_overlap():
 
     host1["a"] = 1
     host1["b"] = 2
-    assert host2.options == {"a": 1, "b": 2}
+    assert host2.options == {"a": [1], "b": [2]}
 
     host2["c"] = 3
-    assert host1.options == {"a": 1, "b": 2}
-    assert host2.options == {"a": 1, "b": 2, "c": 3}
+    assert host1.options == {"a": [1], "b": [2]}
+    assert host2.options == {"a": [1], "b": [2], "c": [3]}
 
     host2["b"] = "q"
-    assert host1.options == {"a": 1, "b": 2}
-    assert host2.options == {"a": 1, "b": "q", "c": 3}
+    assert host1.options == {"a": [1], "b": [2]}
+    assert host2.options == {"a": [1], "b": ["q"], "c": [3]}
 
 
 def test_add_host():

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -17,6 +17,8 @@ Host q
 
         Host h
             HostName hew
+            LocalForward 22 b:22
+            LocalForward 23 b:23
 
     Host q
         HostName qqq
@@ -31,6 +33,8 @@ def test_generate():
     assert new_config == [
         "Host qeh",
         "    HostName hew",
+        "    LocalForward 22 b:22",
+        "    LocalForward 23 b:23",
         "    Port 22",
         "    Protocol 2",
         "",
@@ -50,6 +54,8 @@ def test_process():
     assert process.process(CONTENT) == """\
 Host qeh
     HostName hew
+    LocalForward 22 b:22
+    LocalForward 23 b:23
     Port 22
     Protocol 2
 


### PR DESCRIPTION
SSH allows to set different options with the same name. The most widely
used example as far as I understand is `LocalForward`:

```
Host name
    LocalForward 80 app:8080
    LocalForward 443 app:443
```

This fixes https://github.com/9seconds/concierge/issues/4