### PR TITLE
Allow a host entry to not inherit from its parent name

### DIFF
--- a/concierge/core/parser.py
+++ b/concierge/core/parser.py
@@ -98,6 +98,8 @@ class Host(object):
 
     @property
     def fullname(self):
+        if self.name != "" and self.name[0] == "_":
+            return self.name[1:]
         parent_name = self.parent.fullname if self.parent else ""
         return parent_name + self.name
 


### PR DESCRIPTION
Sometimes you want to group some of your entries by a meaning full name, without having it propagated to its descendants.

Look at the following exemple to understand what I mean. 

Here is a valid (with this patch) `~/.conciergerc` file:

```
-Host perso
    IdentityFile ~/.ssh/id_rsa_perso

    Host _github.com
        HostName github.com
        User git

    Host toto
        HostName toto.com
        User root
```

It will produce the following `~/.ssh/config`

```
Host github.com
    HostName github.com
    IdentityFile ~/.ssh/id_rsa_perso
    User git

Host perso_toto
    HostName toto.com
    IdentityFile ~/.ssh/id_rsa_perso
    User root
```