### PR TITLE
Make consistent templater naming

### DIFF
--- a/concierge/endpoints/common.py
+++ b/concierge/endpoints/common.py
@@ -41,6 +41,7 @@ class App(metaclass=abc.ABCMeta):
         self.boring_syntax = options.boring_syntax
         self.add_header = options.add_header
         self.no_templater = getattr(options, "no_templater", False)
+        self.templater_name = options.use_templater
 
         if options.no_desktop_notifications:
             self.notificator = concierge.notifications.dummy_notifier
@@ -49,7 +50,7 @@ class App(metaclass=abc.ABCMeta):
 
         try:
             self.templater = concierge.templater.resolve_templater(
-                options.use_templater)
+                self.templater_name)
         except KeyError:
             raise ValueError(
                 "Cannot find templater for {0}".format(options.use_templater))

--- a/concierge/endpoints/daemon.py
+++ b/concierge/endpoints/daemon.py
@@ -66,7 +66,7 @@ class Daemon(concierge.endpoints.common.App):
             return self.track()
 
         script = concierge.endpoints.templates.make_systemd_script(
-            self.templater)
+            self.templater_name)
 
         if not self.curlsh:
             script = [

--- a/concierge/endpoints/templates.py
+++ b/concierge/endpoints/templates.py
@@ -59,7 +59,7 @@ def make_systemd_script(templater):
     systemd_config = SYSTEMD_CONFIG.format(
         command=distutils.spawn.find_executable(sys.argv[0]),
         sshconfig=concierge.DEFAULT_SSHCONFIG,
-        templater=templater.name.lower())
+        templater=templater)
 
     yield 'mkdir -p "{0}" || true'.format(systemd_user_path)
     yield 'cat > "{0}" <<EOF\n{1}\nEOF'.format(systemd_user_service_path,

--- a/concierge/templater.py
+++ b/concierge/templater.py
@@ -5,7 +5,7 @@ import pkg_resources
 
 
 TEMPLATER_NAMESPACE = "concierge.templater"
-DEFAULT_RESOLVE_SEQ = "mako", "jinja2"
+DEFAULT_RESOLVE_SEQ = "mako", "jinja"
 
 
 def all_templaters():

--- a/tests/test_templater.py
+++ b/tests/test_templater.py
@@ -33,7 +33,7 @@ def create_templater(name_):
 def mock_plugins(request, monkeypatch):
     templaters = [
         Plugin(create_templater(name))
-        for name in ("mako", "jinja2")]
+        for name in ("mako", "jinja")]
 
     monkeypatch.setattr(
         "pkg_resources.iter_entry_points",
@@ -48,7 +48,7 @@ def test_all_templaters(mock_plugins):
     assert len(tpls) == 3
     assert tpls["dummy"] is templater.Templater
     assert tpls["mako"]().render("q") == "mako q"
-    assert tpls["jinja2"]().render("q") == "jinja2 q"
+    assert tpls["jinja"]().render("q") == "jinja q"
 
 
 def test_resolve_templater_none(mock_plugins):
@@ -62,13 +62,13 @@ def test_resolve_templater_default(mock_plugins):
     assert templater.resolve_templater(None).name == "mako"
     del mock_plugins[0]
 
-    assert templater.resolve_templater(None).name == "jinja2"
+    assert templater.resolve_templater(None).name == "jinja"
     del mock_plugins[0]
 
     assert templater.resolve_templater(None).name == "dummy"
 
 
-@pytest.mark.parametrize("code", ("mako", "jinja2", "dummy"))
+@pytest.mark.parametrize("code", ("mako", "jinja", "dummy"))
 def test_resolve_templater_known(mock_plugins, code):
     assert templater.resolve_templater(code).name == code
 


### PR DESCRIPTION
Do not use templater name if we operate by entrypoint names.

This fixes https://github.com/9seconds/concierge/issues/15