### PR TITLE
Remove "enum34" requirement in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ with open("README.rst", "rt") as readme_fp:
 
 
 REQUIREMENTS = (
-    "inotify_simple",
-    "enum34"
+    "inotify_simple"
 )
 
 


### PR DESCRIPTION
The `enum` module is not actually imported in any part of the codebase and "enum34" isn't relevant for Python version 3.4 and later even if it was relevant. (Current Python is 3.6.x.)

```
freso@koume /t/f/concierge (master)> git grep -i enum|cat
concierge/core/lexer.py:    for index, line in enumerate(lines, start=1):
setup.py:    "enum34"
```